### PR TITLE
chore: upgrade to Go 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module EV3-API
 
-go 1.25.0
+go 1.26.6
 
 require (
 	github.com/ev3go/ev3 v0.0.0-20230218221813-265c69c34aaa


### PR DESCRIPTION
## Summary

- upgrade the module toolchain from Go 1.25.0 to Go 1.26.6
- keep GitHub Actions aligned through the existing `go-version-file: go.mod` configuration

## Validation

- `GOTOOLCHAIN=local go mod tidy -diff`
- `GOTOOLCHAIN=local go test ./...`
- Linux ARMv5 cross-build with Go 1.26.6

Generated by GitHub Copilot via OSS Helper