### PR TITLE
docs: fix ZHAW logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Go binary](https://github.com/EV3-OpenAPI/EV3-API/actions/workflows/build.yaml/badge.svg)](https://github.com/EV3-OpenAPI/EV3-API/actions/workflows/build.yaml)
 
-![ZHAW-logo](https://upload.wikimedia.org/wikipedia/commons/thumb/e/e6/ZHAW_Logo.svg/206px-ZHAW_Logo.svg.png)
+![ZHAW logo](https://upload.wikimedia.org/wikipedia/commons/e/e6/ZHAW_Logo.svg)
 
 # LEGO® MINDSTORMS® EV3-REST
 


### PR DESCRIPTION
## Summary

- replace the broken Wikimedia thumbnail URL, which returns HTTP 400
- use the valid original ZHAW SVG endpoint
- improve the image alt text

## Validation

- fetched the exact new README URL successfully
- confirmed the response is an SVG image
- `git diff --check`

Generated by GitHub Copilot via OSS Helper