### PR TITLE
docs: resize ZHAW logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Go binary](https://github.com/EV3-OpenAPI/EV3-API/actions/workflows/build.yaml/badge.svg)](https://github.com/EV3-OpenAPI/EV3-API/actions/workflows/build.yaml)
 
-![ZHAW logo](https://upload.wikimedia.org/wikipedia/commons/e/e6/ZHAW_Logo.svg)
+<img src="https://upload.wikimedia.org/wikipedia/commons/e/e6/ZHAW_Logo.svg" alt="ZHAW logo" width="132">
 
 # LEGO® MINDSTORMS® EV3-REST
 


### PR DESCRIPTION
## Summary

- render the ZHAW logo at 132 px, one-fifth of its 659 px intrinsic width
- retain the working SVG URL and accessible alt text

## Validation

- rendered the README through GitHub's Markdown API
- confirmed GitHub retains `width="132"` on the proxied image
- confirmed the SVG endpoint returns HTTP 200

Generated by GitHub Copilot via OSS Helper