### PR TITLE
chore: prepare v1.0.6 release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,10 @@ on:
   push:
   release:
     types:
-      - created
+      - published
+
+permissions:
+  contents: read
 
 jobs:
   build-go-server:
@@ -148,6 +151,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-go-server, build-java-client, build-python-client]
     if: github.event_name == 'release' # && github.event.action == 'created'
+    permissions:
+      contents: write
     steps:
       - name: Download go server
         uses: actions/download-artifact@v8
@@ -164,32 +169,17 @@ jobs:
         with:
           name: Python-Wheel
 
-      - name: Upload Go server Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./ev3api-server
-          asset_name: ev3api-server
-          asset_content_type: application/octet-stream
+      - name: Create legacy server asset
+        run: cp ./ev3api-server ./server
 
-      - name: Upload Java Client Release Asset
-        uses: actions/upload-release-asset@v1
+      - name: Upload release assets
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./ev3-java-${{ github.ref_name }}-all.jar
-          asset_name: ev3-java-${{ github.ref_name }}-all.jar
-          asset_content_type: application/java-archive
-
-      - name: Upload Python Client Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./ev3api-${{ github.ref_name }}-py3-none-any.whl
-          asset_name: ev3api-${{ github.ref_name }}-py3-none-any.whl
-          asset_content_type: application/zip
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release upload "${GITHUB_REF_NAME}"
+          ./ev3api-server
+          ./server
+          ./ev3-java-*-all.jar
+          ./ev3api-*-py3-none-any.whl
+          --repo "${GITHUB_REPOSITORY}"
+          --clobber

--- a/README.md
+++ b/README.md
@@ -141,11 +141,7 @@ openapi-generator generate -i openapi/spec.yaml -o clients/ev3-python -g python 
 
 **Important**: The versioning follows [Go semver](https://pkg.go.dev/golang.org/x/mod/semver) specifications, meaning versions have to be in the format "vMAJOR.MINOR.BUGFIX" including the leading "v". This is important when creating a release tag.
 
-If a new release is to be created, the new version number must first be entered in the following files:
-
-* openapi/spec.yaml
-* clients/ev3-java/build.gradle
-* clients/ev3-python/setup.py
+Before creating a release, update the version in `openapi/spec.yaml`. The Java and Python package versions are derived from the release tag.
 
 After that, a new release can be published via the [GitHub GUI](https://github.com/EV3-OpenAPI/EV3-API/releases/new). The repository has a GitHub action that automatically creates the Golang, Java and Python artifacts and attaches them to the release.
 

--- a/internal/utils/updater.go
+++ b/internal/utils/updater.go
@@ -84,7 +84,7 @@ func CheckForNewVersion() {
 	if semver.Compare(currVer, rel.TagName) == -1 {
 		log.Printf("INFO - Newer version found. Current: %s, New: %s", currVer, rel.TagName)
 
-		downloadUrl, err := getAssetWithName(rel.Assets, "server")
+		downloadUrl, err := getServerAsset(rel.Assets)
 		if err != nil {
 			log.Printf("ERROR - No server binary in release. %v", err)
 			return
@@ -116,6 +116,10 @@ func getAssetWithName(assets *[]asset, name string) (string, error) {
 	}
 
 	return "", fmt.Errorf("no asset with the given name found")
+}
+
+func getServerAsset(assets *[]asset) (string, error) {
+	return getAssetWithName(assets, SERVER_FILE_NAME)
 }
 
 func downloadVersion(url string) error {

--- a/internal/utils/updater_test.go
+++ b/internal/utils/updater_test.go
@@ -1,0 +1,18 @@
+package utils
+
+import "testing"
+
+func TestGetServerAssetFindsCurrentServerBinary(t *testing.T) {
+	assets := []asset{
+		{Name: "server", BrowserDownloadUrl: "https://example.com/legacy"},
+		{Name: SERVER_FILE_NAME, BrowserDownloadUrl: "https://example.com/current"},
+	}
+
+	url, err := getServerAsset(&assets)
+	if err != nil {
+		t.Fatalf("getServerAsset() error = %v", err)
+	}
+	if url != "https://example.com/current" {
+		t.Fatalf("getServerAsset() = %q, want current server asset", url)
+	}
+}

--- a/openapi/spec.yaml
+++ b/openapi/spec.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: EV3-REST
   description: EV3-REST
-  version: 0.1.0
+  version: 1.0.6
 servers:
   - url: 'http://127.0.0.1:8080/api/v1'
 


### PR DESCRIPTION
## Summary

- bump the OpenAPI version to 1.0.6
- trigger artifact builds for all published releases
- replace the archived release-upload action with `gh release upload`
- make Java/Python asset discovery independent of `v` tag normalization
- publish both `server` and `ev3api-server` so existing installations can update
- correct the updater to select `ev3api-server`
- document tag-derived client package versions

## Validation

- `go test ./...`
- `actionlint .github/workflows/build.yaml`
- `git diff --check`
- release upload argument-expansion probe for all four assets
- Python `v1.0.6` tag normalization to package version `1.0.6`

Generated by GitHub Copilot via OSS Helper